### PR TITLE
fix: use bullseye directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as builder
+FROM debian:bullseye-slim as builder
 ARG CABAL_VERSION=3.6.2.0
 ARG GHC_VERSION=8.10.7
 


### PR DESCRIPTION
Branched from tag v8.10.7-3.6.2.0-2 to be tagged as v8.10.7-3.6.2.0-3 for consumption downstream.