### PR TITLE
fix: libblst pkgconfig

### DIFF
--- a/libblst.pc
+++ b/libblst.pc
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: libblst
 Description: Multilingual BLS12-381 signature library
 URL: https://github.com/supranational/blst
-Version: 0.3.10
+Version: 0.3.14
 Cflags: -I${includedir}
 Libs: -L${libdir} -lblst


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrects the Version field in libblst.pc from 0.3.10 to 0.3.14 so pkg-config reports the actual installed version. This fixes builds that rely on version checks.

<sup>Written for commit 241530629124ca7f25646c9fefdf17d9e33f4626. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

