### PR TITLE
feat: ghc 9.6.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM debian:bookworm-slim AS builder
 ARG CABAL_VERSION=3.12.1.0
-ARG GHC_VERSION=9.6.6
+ARG GHC_VERSION=9.6.7
 ARG LIBSODIUM_REF=dbb48cce
 ARG SECP256K1_REF=v0.3.2
 ARG BLST_REF=v0.3.14
 
 WORKDIR /code
+
+# UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 # system dependencies
 ENV DEBIAN_FRONTEND=noninteractive
@@ -21,6 +25,7 @@ RUN apt-get update -y && \
     libssl-dev \
     libsystemd-dev \
     libtinfo-dev \
+    liburing-dev \
     llvm-dev \
     zlib1g-dev \
     make \


### PR DESCRIPTION
Also add UTF-8 env settings and add liburing-dev for cardano-node 10.7+

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade GHC to 9.6.7 in the builder image. Set UTF-8 locale (LANG/LC_ALL) and add `liburing-dev` for `cardano-node` 10.7+ builds.

<sup>Written for commit 7a66ece6733d5f661b4c133ac0ca12e62b90d3ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compiler toolchain to the latest patch version for improved stability and security.
  * Enhanced Unicode support with UTF-8 locale configuration for better internationalization compatibility.
  * Improved build environment dependencies for optimized performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->