### PR TITLE
feat: libsnappy-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -y && \
     libgmp-dev \
     liblmdb-dev \
     libnuma-dev \
+    libsnappy-dev \
     libssl-dev \
     libsystemd-dev \
     libtinfo-dev \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `libsnappy-dev` to the Docker image to provide Snappy headers and libraries for builds. This enables components that require Snappy and prevents missing-dependency build failures.

<sup>Written for commit 45107d6607161156228c4599427c6f40e620c862. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure dependencies to enhance system stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->