### PR TITLE
feat: protof-compiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get update -y && \
     wget \
     libncursesw5 \
     libtool \
-    autoconf
+    autoconf \
+    protobuf-compiler
 
 # GHC
 ENV GHC_VERSION=${GHC_VERSION}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `protobuf-compiler` to the Docker build image to enable Protocol Buffers code generation during builds. This prevents missing toolchain errors in CI and local development.

<sup>Written for commit 2ed9aa4108e2c7dd916011308f2e27b11e1e2645. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies in the Docker configuration for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->