### PR TITLE
feat: ghc 9.12.3 and cabal 3.14.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim AS builder
-ARG CABAL_VERSION=3.12.1.0
-ARG GHC_VERSION=9.6.7
+ARG CABAL_VERSION=3.14.2.0
+ARG GHC_VERSION=9.12.3
 ARG LIBSODIUM_REF=dbb48cce
 ARG SECP256K1_REF=v0.3.2
 ARG BLST_REF=v0.3.14
@@ -42,9 +42,9 @@ RUN apt-get update -y && \
 
 # GHC
 ENV GHC_VERSION=${GHC_VERSION}
-RUN wget https://downloads.haskell.org/~ghc/${GHC_VERSION}/ghc-${GHC_VERSION}-$(uname -m)-deb10-linux.tar.xz \
-    && tar -xf ghc-${GHC_VERSION}-$(uname -m)-deb10-linux.tar.xz \
-    && rm ghc-${GHC_VERSION}-$(uname -m)-deb10-linux.tar.xz \
+RUN wget https://downloads.haskell.org/~ghc/${GHC_VERSION}/ghc-${GHC_VERSION}-$(uname -m)-deb12-linux.tar.xz \
+    && tar -xf ghc-${GHC_VERSION}-$(uname -m)-deb12-linux.tar.xz \
+    && rm ghc-${GHC_VERSION}-$(uname -m)-deb12-linux.tar.xz \
     && cd ghc-${GHC_VERSION}-$(uname -m)-unknown-linux \
     && ./configure \
     && make install
@@ -52,9 +52,9 @@ RUN wget https://downloads.haskell.org/~ghc/${GHC_VERSION}/ghc-${GHC_VERSION}-$(
 # cabal
 ENV CABAL_VERSION=${CABAL_VERSION}
 ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:/root/.local/bin:$PATH"
-RUN wget https://downloads.haskell.org/~cabal/cabal-install-${CABAL_VERSION}/cabal-install-${CABAL_VERSION}-$(uname -m)-linux-deb10.tar.xz \
-    && tar -xf cabal-install-${CABAL_VERSION}-$(uname -m)-linux-deb10.tar.xz \
-    && rm cabal-install-${CABAL_VERSION}-$(uname -m)-linux-deb10.tar.xz \
+RUN wget https://downloads.haskell.org/~cabal/cabal-install-${CABAL_VERSION}/cabal-install-${CABAL_VERSION}-$(uname -m)-linux-deb12.tar.xz \
+    && tar -xf cabal-install-${CABAL_VERSION}-$(uname -m)-linux-deb12.tar.xz \
+    && rm cabal-install-${CABAL_VERSION}-$(uname -m)-linux-deb12.tar.xz \
     && mkdir -p ~/.local/bin \
     && mv cabal ~/.local/bin/ \
     && cabal update && cabal --version


### PR DESCRIPTION
This is needed by newer versions of [cardano-wallet](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2026-05-11)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Docker image to use `GHC` 9.12.3 and `cabal-install` 3.14.2.0, switching to Debian 12 tarballs to match the Bookworm base. Supports the latest `cardano-wallet` release (v2026-05-11+) that requires this toolchain.

<sup>Written for commit 01cd35adee04005698aea6bffe9441b5051c0d8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/docker-haskell/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Haskell build environment to newer tool versions, including the compiler and package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->